### PR TITLE
chore: change package b

### DIFF
--- a/libs/package-b/src/lib/package-b.ts
+++ b/libs/package-b/src/lib/package-b.ts
@@ -1,3 +1,3 @@
 export function packageB(): string {
-  return 'Package B in main!';
+  return 'Package B in PR!';
 }

--- a/tools/scripts/create-sandbox.ts
+++ b/tools/scripts/create-sandbox.ts
@@ -4,6 +4,7 @@ import { copyFileSync, existsSync, ensureDirSync } from 'fs-extra';
 import { rmSync, writeFileSync } from 'fs';
 
 const rootPath = join(__dirname, '../../');
+const tmpPath = join(rootPath, './tmp';
 
 async function spawnLocalRegistry(): Promise<cp.ChildProcess> {
   cp.execSync('npx kill-port 4872');
@@ -37,7 +38,9 @@ function publishAllPackages() {
   });
 }
 
-rmSync(join(rootPath, './tmp'), { recursive: true });
+if( existsSync(tmpPath)) {
+    rmSync(tmpPath, { recursive: true });
+}
 const sandboxPath = join(rootPath, './tmp/sandbox');
 ensureDirSync(sandboxPath);
 


### PR DESCRIPTION
Upon cloning the repo, and running `npm run create-sandbox`, you can cd into the new sandbox folder and run the CLI tool.

You should see "package b in PR" instead of "package b in main". This indicates the sandbox is running the cli tool as is in the pr branch, rather than a released version. In this case, there are no released versions so the command would fail entirely rather than print.